### PR TITLE
Move `Tuna` menu from `Edit` to `Debug`.

### DIFF
--- a/Tuna/Tuna.m
+++ b/Tuna/Tuna.m
@@ -17,6 +17,10 @@ static Tuna *sharedPlugin;
 @interface Tuna()
 
 @property (nonatomic, strong, readwrite) NSBundle *bundle;
+
+/// Install Tuna menu item in Xcode.
+- (void)installMenuItem:(NSMenuItem*)menu;
+
 @end
 
 @implementation Tuna
@@ -71,11 +75,18 @@ static Tuna *sharedPlugin;
     })];
     
     pluginMenuItem.submenu = pluginMenu;
-    
-    NSMenuItem *editMenuItem = [[NSApp mainMenu] itemWithTitle:@"Edit"];
-    
-    [[editMenuItem submenu] addItem:[NSMenuItem separatorItem]];
-    [[editMenuItem submenu] addItem:pluginMenuItem];
+	
+    [self installMenuItem:pluginMenuItem];
+}
+
+- (void)installMenuItem:(NSMenuItem *)menuItem
+{
+	NSMenuItem *debugMenuItem = [[NSApp mainMenu] itemWithTitle:@"Debug"];
+	NSMenu *debugSubmenu = debugMenuItem.submenu;
+	NSMenuItem *debugBreakpointsMenuItem = [debugSubmenu itemWithTitle:@"Breakpoints"];
+	NSUInteger indexForInsertMenu = [debugSubmenu.itemArray indexOfObject:debugBreakpointsMenuItem] + 1;
+	
+	[debugSubmenu insertItem:menuItem atIndex:indexForInsertMenu];
 }
 
 - (void)setPrintBreakpoint


### PR DESCRIPTION
Generally, `Edit` menu has menus for editing a TEXT itself.
Tuna's menu is used to put Breakpoints to source code.

In Xcode, menu items which use to control breakpoints are gathered in the `Debug` menu.
Because, I think that it might better to move `Tuna` menu into 'Debug' menu.
