### PR TITLE
Fix a bug that a breakpoint is always set at line 1 in Version Editor.

### DIFF
--- a/Tuna.xcodeproj/project.pbxproj
+++ b/Tuna.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		5EF099551AB2002C00AE2462 /* IDEEditorHistoryStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEEditorHistoryStack.h; sourceTree = "<group>"; };
 		5EF099561AB2008F00AE2462 /* IDEEditorHistoryItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEEditorHistoryItem.h; sourceTree = "<group>"; };
 		5EF5F0891AAF5581001CC293 /* IDEEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEEditor.h; sourceTree = "<group>"; };
+		B17EF2B01ACEB711000CF74F /* IDEComparisonEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEComparisonEditor.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +95,7 @@
 				5E692F7B1AAF4C2B006780D4 /* IDEEditorArea.h */,
 				5ECDEFC81AAF457300F8EC91 /* IDESourceCodeEditor.h */,
 				5E692F7A1AAF4B86006780D4 /* IDESourceCodeComparisonEditor.h */,
+				B17EF2B01ACEB711000CF74F /* IDEComparisonEditor.h */,
 				5EC687DD1AAF4812004DC13C /* IDELogBreakpointAction.h */,
 				5EF099551AB2002C00AE2462 /* IDEEditorHistoryStack.h */,
 				5EF099561AB2008F00AE2462 /* IDEEditorHistoryItem.h */,

--- a/Tuna/IDEComparisonEditor.h
+++ b/Tuna/IDEComparisonEditor.h
@@ -1,0 +1,19 @@
+//
+//  IDEComparisonEditor.h
+//  Tuna
+//
+//  Created by Tomohiro Kumagai on H27/04/03.
+//  Copyright (c) 平成27年 Toshihiro Morimoto. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class IDEEditor;
+
+@interface IDEComparisonEditor : IDEEditor
+
+- (id)secondaryEditorInstance;
+- (id)primaryEditorInstance;
+- (id)keyEditor;
+
+@end

--- a/Tuna/IDESourceCodeComparisonEditor.h
+++ b/Tuna/IDESourceCodeComparisonEditor.h
@@ -9,8 +9,9 @@
 #import <Foundation/Foundation.h>
 
 @class DVTSourceTextView;
+@class IDEComparisonEditor;
 
-@interface IDESourceCodeComparisonEditor : NSObject
+@interface IDESourceCodeComparisonEditor : IDEComparisonEditor
 
 @property(readonly) DVTSourceTextView *keyTextView;
 

--- a/Tuna/Xcode.h
+++ b/Tuna/Xcode.h
@@ -24,6 +24,7 @@
 #import "IDEEditorContext.h"
 #import "IDEEditorArea.h"
 #import "IDESourceCodeEditor.h"
+#import "IDEComparisonEditor.h"
 #import "IDESourceCodeComparisonEditor.h"
 #import "IDELogBreakpointAction.h"
 #import "IDEEditorHistoryStack.h"


### PR DESCRIPTION
When I set a breakpoint using Tuna in Version Editor, the breakpoint is always set at line 1 because of Tuna was not able to get current editor. I fixed it.
