### PR TITLE
Remove duplicated menu item `Toggle Breakpoint`.

### DIFF
--- a/Tuna/Tuna.m
+++ b/Tuna/Tuna.m
@@ -96,15 +96,6 @@ typedef NS_ENUM(NSInteger, EditorType)
         item;
     })];
     [pluginMenu addItem:({
-        NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"Toggle Breakpoint"
-                                                      action:@selector(toggleEnableFileBreakpoint)
-                                               keyEquivalent:@"["];
-        [item setKeyEquivalentModifierMask:NSShiftKeyMask|NSCommandKeyMask];
-
-        item.target = self;
-        item;
-    })];
-    [pluginMenu addItem:({
         NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"Clear All File Breakpoint"
                                                       action:@selector(clearAllFileBreakpoint)
                                                keyEquivalent:@"]"];


### PR DESCRIPTION
In Tuna's menu, Two same menu item named `Toggle Breakpoint` are exist.
I was removed one of them.
