### PR TITLE
Import frameworks from plist.

### DIFF
--- a/Tuna.xcodeproj/project.pbxproj
+++ b/Tuna.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5ECDEFB71AAF414B00F8EC91 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5ECDEFB61AAF414B00F8EC91 /* Foundation.framework */; };
 		5ECDEFBC1AAF414B00F8EC91 /* Tuna.xcscheme in Resources */ = {isa = PBXBuildFile; fileRef = 5ECDEFBB1AAF414B00F8EC91 /* Tuna.xcscheme */; };
 		5ECDEFBF1AAF414B00F8EC91 /* Tuna.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ECDEFBE1AAF414B00F8EC91 /* Tuna.m */; };
+		B1F3407A1B088CAB00208BB0 /* TunaImportFrameworkManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B1F340791B088CAB00208BB0 /* TunaImportFrameworkManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,6 +59,8 @@
 		5EF099561AB2008F00AE2462 /* IDEEditorHistoryItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEEditorHistoryItem.h; sourceTree = "<group>"; };
 		5EF5F0891AAF5581001CC293 /* IDEEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEEditor.h; sourceTree = "<group>"; };
 		B17EF2B01ACEB711000CF74F /* IDEComparisonEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IDEComparisonEditor.h; sourceTree = "<group>"; };
+		B1F340781B088CAB00208BB0 /* TunaImportFrameworkManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TunaImportFrameworkManager.h; sourceTree = "<group>"; };
+		B1F340791B088CAB00208BB0 /* TunaImportFrameworkManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TunaImportFrameworkManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,6 +175,8 @@
 				5ECDEFBE1AAF414B00F8EC91 /* Tuna.m */,
 				5EA1E4731B066B9600723C7D /* TunaSwizzler.h */,
 				5EA1E4741B066B9600723C7D /* TunaSwizzler.m */,
+				B1F340781B088CAB00208BB0 /* TunaImportFrameworkManager.h */,
+				B1F340791B088CAB00208BB0 /* TunaImportFrameworkManager.m */,
 				5ECDEFB91AAF414B00F8EC91 /* Supporting Files */,
 			);
 			path = Tuna;
@@ -279,6 +284,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5ECDEFBF1AAF414B00F8EC91 /* Tuna.m in Sources */,
+				B1F3407A1B088CAB00208BB0 /* TunaImportFrameworkManager.m in Sources */,
 				5EA1E4751B066B9600723C7D /* TunaSwizzler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tuna/TunaImportFrameworkManager.h
+++ b/Tuna/TunaImportFrameworkManager.h
@@ -1,0 +1,42 @@
+//
+//  TunaImportManager.h
+//  Tuna
+//
+//  Created by Tomohiro Kumagai on H27/05/17.
+//  Copyright (c) 平成27年 Toshihiro Morimoto. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "DBGLLDBSession.h"
+#import "DBGLLDBLauncher.h"
+
+/*!
+ This object supports to import frameworks to LLDB when debugging.
+
+ Read from ~/Library/Preferences/com.dealforest.Tuna.import.plist.
+ If the file is not exists, create a import.plist file by default.
+ */
+@interface TunaImportFrameworkManager : NSObject
+
+/// Initialize with Default Import framework list.
+- (nonnull instancetype)init;
+
+/// Get path of import.plist. If failed to get import.plist, returns nil.
+- (nullable NSString*)importListPath;
+
+/// Get import framework list
+@property (readonly, strong) NSArray* __nonnull importFrameworks;
+
+/// Save import framework list.
+- (BOOL)save;
+
+/// Load import framework list.
+- (BOOL)load;
+
+/// Import Frameworks to LLDB.
+- (void)doImportWithSession:(nullable DBGLLDBSession*)session;
+
+/// Print description to LLDB.
+- (void)printDescriptionWithSession:(nullable DBGLLDBSession*)session;
+
+@end

--- a/Tuna/TunaImportFrameworkManager.m
+++ b/Tuna/TunaImportFrameworkManager.m
@@ -1,0 +1,164 @@
+//
+//  TunaImportManager.m
+//  Tuna
+//
+//  Created by Tomohiro Kumagai on H27/05/17.
+//  Copyright (c) 平成27年 Toshihiro Morimoto. All rights reserved.
+//
+
+#import "TunaImportFrameworkManager.h"
+#import "DBGLLDBSession.h"
+
+@interface TunaImportFrameworkManager ()
+
+@property (readonly) BOOL _isImportListFileExists;
+@property (readonly) NSArray* __nonnull _defaultImportFrameworks;
+
+- (BOOL)_createImportListFile:(nonnull NSString*)path withImportFrameworks:(nonnull NSArray*)importFrameworks;
+
+@end
+
+@implementation TunaImportFrameworkManager
+{
+    NSArray* _importFrameworks;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self)
+    {
+        [self load];
+    }
+    
+    return self;
+}
+
+- (nonnull NSArray*)_defaultImportFrameworks
+{
+    return @[ @"UIKit", @"Foundation" ];
+}
+
+- (nullable NSString*)importListPath
+{
+    NSArray* libraryDirectories = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    
+    if (libraryDirectories.count > 0)
+    {
+        return [[NSString alloc] initWithFormat:@"%@/Preferences/%@", libraryDirectories.firstObject, @"net.dealforest.Tuna.import.plist"];
+    }
+    else
+    {
+        return nil;
+    }
+}
+
+- (nonnull NSString*)description
+{
+    NSArray* importFrameworks = self.importFrameworks;
+    
+    switch (importFrameworks.count)
+    {
+        case 0:
+            return @"(none)";
+            
+        case 1:
+            return importFrameworks.firstObject;
+            
+        default:
+        {
+            NSArray* importFrameworksWithoutLastElement = [importFrameworks subarrayWithRange:NSMakeRange(0, importFrameworks.count - 1)];
+            NSString* importFrameworksWithoutLastElementDescription = [importFrameworksWithoutLastElement componentsJoinedByString:@", "];
+        
+            return [[NSString alloc] initWithFormat:@"%@ and %@", importFrameworksWithoutLastElementDescription, importFrameworks.lastObject];
+        }
+    }
+}
+
+- (BOOL)load
+{
+    _importFrameworks = nil;
+    
+    NSString* importListPath = self.importListPath;
+    
+    if (!importListPath)
+    {
+        NSLog(@"INTERNAL ERROR: Failed to get a path of import frameworks list.");
+        return false;
+    }
+
+    NSFileManager* fileManager = [NSFileManager defaultManager];
+    
+    if ([fileManager fileExistsAtPath:importListPath isDirectory:NO])
+    {
+        NSArray* importFrameworks = [[NSArray alloc] initWithContentsOfFile:importListPath];
+        
+        if (importFrameworks)
+        {
+            _importFrameworks = importFrameworks;
+
+            return YES;
+        }
+        else
+        {
+            NSLog(@"INTERNAL ERROR: Failed to load an import frameworks list '%@'.", importListPath);
+            
+            return NO;
+        }
+    }
+    else
+    {
+        _importFrameworks = self._defaultImportFrameworks;
+        
+        if ([self _createImportListFile:importListPath withImportFrameworks:self.importFrameworks])
+        {
+            return YES;
+        }
+        else
+        {
+            NSLog(@"INTERNAL ERROR: Failed to load an import frameworks list.");
+
+            return NO;
+        }
+    }
+}
+
+- (BOOL)save
+{
+    NSString* path = self.importListPath;
+    NSArray* importFrameworks = self.importFrameworks;
+    
+    return [self _createImportListFile:path withImportFrameworks:importFrameworks];
+}
+
+- (BOOL)_createImportListFile:(nonnull NSString*)path withImportFrameworks:(nonnull NSArray*)importFrameworks
+{
+    return [importFrameworks writeToFile:path atomically:NO];
+}
+
+- (void)doImportWithSession:(nullable DBGLLDBSession*)session
+{
+    if (session)
+    {
+        for (NSString* framework in self.importFrameworks)
+        {
+            NSString* command = [[NSString alloc] initWithFormat:@"p @import %@\n", framework];
+            [[session launcher] _executeLLDBCommands:command];
+        }
+    }
+}
+
+- (void)printDescriptionWithSession:(nullable DBGLLDBSession*)session
+{
+    if (session)
+    {
+        if (self.importFrameworks.count > 0)
+        {
+            NSString* command = [[NSString alloc] initWithFormat:@"po \"import framework %@\"\n", self.description];
+            [[session launcher] _executeLLDBCommands:command];
+        }
+    }
+}
+
+@end

--- a/Tuna/TunaImportFrameworkManager.m
+++ b/Tuna/TunaImportFrameworkManager.m
@@ -155,7 +155,7 @@
     {
         if (self.importFrameworks.count > 0)
         {
-            NSString* command = [[NSString alloc] initWithFormat:@"po \"import framework %@\"\n", self.description];
+            NSString* command = [[NSString alloc] initWithFormat:@"po @\"import framework %@\"\n", self.description];
             [[session launcher] _executeLLDBCommands:command];
         }
     }


### PR DESCRIPTION
By applying this PR, Tuna get import framework list from the plist file stored `~/Library/Preferences/net.dealforest.Tuna.import.plist`. If the plist file is not exists, the file will create.

When you want to customize import framework list, you can open `~/Library/Preferences/net.dealforest.Tuna.import.plist` using Xcode and edit it.

After editing, new import framework list will be applied by restarting Xcode.
